### PR TITLE
Expression is always true

### DIFF
--- a/vmread/mem.c
+++ b/vmread/mem.c
@@ -278,7 +278,6 @@ uint64_t VTranslate(const ProcessData* data, uint64_t dirBase, uint64_t address)
 
 void SetMemCacheTime(size_t newTime)
 {
-	if (newTime >= 0)
 		vtCacheTimeMS = newTime;
 }
 


### PR DESCRIPTION
#5 since size_t is unsigned int it is never lower than 0, so this check is unnecessary and can be removed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mistery52/apex_dma_kvm_pub/6)
<!-- Reviewable:end -->
